### PR TITLE
Updated the readme link for mobx concept documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ dependencies {
 }
 ```
 ## More
-* https://mobx.js.org/intro/concepts.html - original MobX documentation
+* https://mobx.js.org/the-gist-of-mobx.html - original MobX documentation
 * https://github.com/mobxjs/mobx.dart - MobX for Dart/Flutter
 * https://www.packtpub.com/web-development/mobx-quick-start-guide
 * https://hackernoon.com/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254 - an in-depth explanation of MobX


### PR DESCRIPTION
`README.md` was pointing to a deprecated HTTP URL for `Mobx Concept`.